### PR TITLE
Adds a small indicator when sensor is timing out

### DIFF
--- a/src/display_module.cpp
+++ b/src/display_module.cpp
@@ -243,7 +243,12 @@ void display_module_set_ble(uint8_t state)
 
 void display_module_set_reading(uint8_t state)
 {
-    if(state > 0 )
+    if (display_data.sensor_state == SENSOR_NOT_FOUND) {
+        display.setColor(OLEDDISPLAY_COLOR::WHITE);
+        display.drawLine(114, 51, 126, 63);
+    }
+
+    if(state > 0)
     {
         display.drawCircle(120, 57, 6);
     }    
@@ -258,6 +263,10 @@ void display_module_set_calibrating(uint8_t state)
     display.drawRect(112, 32, 16, 16);    
 }
 
+void display_module_set_sensor_state(uint8_t state)
+{
+    display_data.sensor_state = state;
+}
 
 void display_module_defaults(struct display_preferences* preferences)
 {

--- a/src/display_module.h
+++ b/src/display_module.h
@@ -47,7 +47,8 @@ struct st_display_data
     uint32_t icon_warming : 1,
              icon_ble : 1,
              icon_calibrating: 1,
-             icon_reading: 1;
+             icon_reading: 1,
+             sensor_state: 1;
 
     uint16_t ppm;
     uint16_t battery;
@@ -66,6 +67,7 @@ void display_module_set_warming(uint8_t state);
 void display_module_set_ble(uint8_t state);
 void display_module_set_calibrating(uint8_t state);
 void display_module_set_reading(uint8_t state);
+void display_module_set_sensor_state(uint8_t state);
 
 void display_module_draw_ppm();
 void display_module_draw_ppm_graph();

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -21,7 +21,7 @@ void setup() {
   delay(1000); /**< Wait until serial terminal has done with platform messages.. */
   app_init();
   config_module_init();
-  sensor_module_init();  
+  sensor_module_init();
   display_module_init();
 }
 
@@ -49,6 +49,9 @@ void sensor_tasker()
   display_module_set_ppm(ppm);
   display_module_draw_ppm();  
   display_module_draw_ppm_graph();
+
+  uint16_t state = sensor_module_get_state();
+  display_module_set_sensor_state(state);
 }
 
 void battery_tasker()

--- a/src/sensor_module.cpp
+++ b/src/sensor_module.cpp
@@ -18,11 +18,12 @@ WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN 
 static SoftwareSerial serial(SENSOR_RX_PIN, SENSOR_TX_PIN);                   
 static struct sensor_preferences* preferences = 0x00;
 static MHZ19 sensor;
+
 void sensor_module_init()
 {  
     preferences = &config_module_get_preferences()->sensor;
     serial.begin(SENSOR_BAUDRATE);                                    
-    sensor.begin(serial);                                
+    sensor.begin(serial);
     if(preferences > 0x00)
     {
         sensor.autoCalibration((preferences->flags & SENSOR_FLAGS_AUTOCALIBRATION_ENABLE)?1:0);  
@@ -38,4 +39,12 @@ void sensor_module_defaults(struct sensor_preferences* preferences)
 uint16_t sensor_module_ppm_read()
 {
     return sensor.getCO2(true, true);
+}
+
+uint16_t sensor_module_get_state()
+{
+    if (sensor.errorCode == RESULT_TIMEOUT) {
+        return SENSOR_NOT_FOUND;
+    }
+    return SENSOR_OK;
 }

--- a/src/sensor_module.h
+++ b/src/sensor_module.h
@@ -18,6 +18,9 @@ WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN 
 #define SENSOR_MAX_PPM 5000          
 #define SENSOR_MIN_PPM 0
 
+#define SENSOR_OK 0
+#define SENSOR_NOT_FOUND 1
+
 #define SENSOR_FLAGS_DEFAULT 0x00
 #define SENSOR_FLAGS_AUTOCALIBRATION_ENABLE 0x01
 
@@ -30,4 +33,6 @@ struct sensor_preferences
 void sensor_module_init();
 void sensor_module_defaults(struct sensor_preferences* preferences);
 uint16_t sensor_module_ppm_read();
+uint16_t sensor_module_get_state();
+
 #endif


### PR DESCRIPTION
When the sensor boots up it's easy to see if there are readings or not (0000 is shown and no graph). After some time running if sensor is not correctly attached, it can stop reading ppm information.

This PR adds a small line on the reading circle to show that it's able to read info from the sensor or not.